### PR TITLE
add integer config

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ A plugin for estimating time that could be spent for an article reading.
 Your pelicanconf.py should include following new options:
 - **ERT_WPM**: number of words that human usually read per one minute
 - **ERT_FORMAT**: format string, that contains `{time}` entry.
+- **ERT_INT** `True` or `False` whether or not the time displays as an integer
+    or a float
 
 ### Default configuration
 ```
@@ -18,7 +20,7 @@ ERT_WPM = 200
 ERT_FORMAT = '{time} read'
 ```
 
-## Accessing the estimated reading time imformation
+## Accessing the estimated reading time information
 For example, this is the code from my `article.html` template:
 ```
 {% if article.ert %} <strong>{{ article.ert }} </strong> {% endif %}

--- a/ert.py
+++ b/ert.py
@@ -7,11 +7,12 @@ log = logging.getLogger(__name__)
 
 ERT_WPM = 200  # words per minute by default
 ERT_FORMAT = '{time} read'
+ERT_INT = False
 
 
 def initialize(gen):
     global ERT_WPM, ERT_FORMAT
-    for option in ['ERT_WPM', 'ERT_FORMAT']:
+    for option in ['ERT_WPM', 'ERT_FORMAT', 'ERT_INT']:
         if not option in gen.settings.keys():
             log.warning(
                 'The necessary config option is missing: {},\
@@ -30,16 +31,27 @@ def estimate(text):
     if minutes < 1:
         time = '< 1 min'
     elif minutes < 60:
-        time = '{} min'.format(round(minutes))
+        rounded = round(minutes)
+        if ERT_INT :
+            rounded = int(rounded)
+        time = '{} min'.format(rounded)
     else:
         if time // 60 == 1:
             end = ''
         else:
             end = 's'
+
+        rounded_minutes = round(minutes // 60)
+        rounded_hours = round(minutes - rounded_minutes * 60)
+
+        if ERT_INT:
+            rounded_minutes = int(rounded_minutes)
+            rounded_hours = int(rounded_hours)
+
         time = '{} hour{} {} min'.format(
-            round(minutes // 60),
+            rounded_minutes,
             end,
-            round(minutes - (minutes // 60) * 60)
+            rounded_hours 
         )
     return ERT_FORMAT.format(time=time)
 


### PR DESCRIPTION
Adds a config option to convert number to an integer rather than a float on output (reads as `6 min read` instead of `6.0 min read`)